### PR TITLE
Improve handling of PDF files

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -70,6 +70,7 @@ def start_runner():
 if __name__ == "__main__":
     logging.getLogger("urllib3").setLevel(logging.WARNING)
     logging.getLogger("werkzeug").setLevel(logging.INFO)
+    logging.getLogger("chardet").setLevel(logging.INFO)
     app.logger.setLevel(logging.INFO)
 
     start_runner()

--- a/tapeworm/services.py
+++ b/tapeworm/services.py
@@ -22,7 +22,8 @@ class TitleExtractor:
         )
         res = requests.get(url, headers={"User-Agent": user_agent})
         res.raise_for_status()
-
+        if res.headers["Content-Type"] == "application/pdf":
+            res.encoding = "utf-8"
         return (res.text, res.url)
 
     def retrieve_url_title(self, url) -> (str, str):


### PR DESCRIPTION
The `requests` library will iterate through all encodings to identify a suitable encoding scheme to decode the content if the encoding is not identified ([see link](https://github.com/psf/requests/blob/master/requests/models.py#L874)). This may cause latency when the bot is presented with larger PDFs. Furthermore, the logging messages for the `chardet` is not silenced by the bot, resulting in clutter in logs. 

The proposed fix addresses the issues by 1) removing the need to detect encoding schemes when handling PDFs and 2) silences the logs generated by `chardet`.